### PR TITLE
feat: add universities and majors endpoints to lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ KADA Connect serves as a bridge between trainees and companies, enabling:
 
 ### Lookup API - High-Performance Reference Data
 - Industries: Get comprehensive list of industries
+- Universities: Get comprehensive list of universities
+- Majors: Get comprehensive list of academic majors
 - Tech Roles: Browse technology roles and categories
 - Suggestions: Smart tech skill suggestions
 - Popular Data: Most common industries, roles, and skills
@@ -179,12 +181,16 @@ http://localhost:3001/api
 #### Lookup API
 | Method | Endpoint | Description |
 |--------|-----------|-------------|
-| GET | `/` | Get all lookup data |
+| GET | `/lookup/all` | Get all lookup data |
 | GET | `/industries` | Get all industries |
+| GET | `/universities` | Get all universities |
+| GET | `/majors` | Get all academic majors |
 | GET | `/tech-roles` | Get all tech roles |
 | GET | `/tech-role-categories` | Get tech role categories |
 | GET | `/tech-roles/category/:category` | Get tech roles by category |
 | GET | `/search/industries` | Search industries |
+| GET | `/search/universities` | Search universities |
+| GET | `/search/majors` | Search academic majors |
 | GET | `/search/tech-roles` | Search tech roles |
 | GET | `/suggestions/tech-skills` | Get tech skill suggestions |
 | GET | `/lookup/all` | Get all lookup data |

--- a/collection/KADA-Connect-be - Complete API Test Suite.postman_collection.json
+++ b/collection/KADA-Connect-be - Complete API Test Suite.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "4e0b1244-56a9-4dd4-a903-fab165693dc9",
 		"name": "KADA-Connect-be - Complete API Test Suite",
-		"description": "Comprehensive API test suite for KADA Connect Backend covering all 41 endpoints with authentication, validation, and error handling tests.",
+		"description": "Comprehensive API test suite for KADA Connect Backend covering all 49 endpoints with authentication, validation, and error handling tests.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
 		"_exporter_id": "34071377"
 	},
@@ -1539,6 +1539,94 @@
 					"response": []
 				},
 				{
+					"name": "Get All Universities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Universities response is an array\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Universities are unique strings\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        const uniqueUniversities = [...new Set(jsonData)];",
+									"        pm.expect(uniqueUniversities.length).to.equal(jsonData.data.length);",
+									"        jsonData.data.forEach(university => {",
+									"            pm.expect(university).to.be.a('string');",
+									"            pm.expect(university).to.not.be.empty;",
+									"        });",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Response time is acceptable\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(1500);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": "{{baseUrl}}/api/universities",
+						"description": "Get all unique universities from both students and lookup data"
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Majors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Majors response is an array\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Majors are unique strings\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        const uniqueMajors = [...new Set(jsonData)];",
+									"        pm.expect(uniqueMajors.length).to.equal(jsonData.data.length);",
+									"        jsonData.data.forEach(major => {",
+									"            pm.expect(major).to.be.a('string');",
+									"            pm.expect(major).to.not.be.empty;",
+									"        });",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Response time is acceptable\", function () {",
+									"    pm.expect(pm.response.responseTime).to.be.below(1500);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": "{{baseUrl}}/api/majors",
+						"description": "Get all unique majors from both students and lookup data"
+					},
+					"response": []
+				},
+				{
 					"name": "Search Industries",
 					"event": [
 						{
@@ -1642,6 +1730,138 @@
 							]
 						},
 						"description": "Search tech roles with query parameter"
+					},
+					"response": []
+				},
+				{
+					"name": "Search Universities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Search results contain query term\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    const searchTerm = pm.request.url.query.get('q');",
+									"    if (jsonData.data.length > 0) {",
+									"        const found = jsonData.data.some(university => {",
+									"            return university.toLowerCase().includes(searchTerm.toLowerCase());",
+									"        });",
+									"        pm.expect(found).to.be.true;",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Search results are an array\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Search results are valid strings\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        jsonData.data.forEach(university => {",
+									"            pm.expect(university).to.be.a('string');",
+									"            pm.expect(university).to.not.be.empty;",
+									"        });",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/search/universities?q=university",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"search",
+								"universities"
+							],
+							"query": [
+								{
+									"key": "q",
+									"value": "university",
+									"description": "Search query for universities"
+								}
+							]
+						},
+						"description": "Search universities with query parameter and fuzzy matching"
+					},
+					"response": []
+				},
+				{
+					"name": "Search Majors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Search results contain query term\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    const searchTerm = pm.request.url.query.get('q');",
+									"    if (jsonData.data.length > 0) {",
+									"        const found = jsonData.data.some(major => {",
+									"            return major.toLowerCase().includes(searchTerm.toLowerCase());",
+									"        });",
+									"        pm.expect(found).to.be.true;",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Search results are an array\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.be.an('array');",
+									"});",
+									"",
+									"pm.test(\"Search results are valid strings\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        jsonData.data.forEach(major => {",
+									"            pm.expect(major).to.be.a('string');",
+									"            pm.expect(major).to.not.be.empty;",
+									"        });",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/search/majors?q=computer",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"search",
+								"majors"
+							],
+							"query": [
+								{
+									"key": "q",
+									"value": "computer",
+									"description": "Search query for majors"
+								}
+							]
+						},
+						"description": "Search majors with query parameter and fuzzy matching"
 					},
 					"response": []
 				},
@@ -1959,6 +2179,140 @@
 							]
 						},
 						"description": "Get most popular tech skills by count"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Popular Universities",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Popular universities are sorted by count\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 1) {",
+									"        for (let i = 0; i < jsonData.data.length - 1; i++) {",
+									"            pm.expect(jsonData[i].count).to.be.at.least(jsonData[i + 1].count);",
+									"        }",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Each item has university and count\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        jsonData.data.forEach(item => {",
+									"            pm.expect(item).to.have.property('university');",
+									"            pm.expect(item).to.have.property('count');",
+									"            pm.expect(item.count).to.be.a('number');",
+									"            pm.expect(item.university).to.be.a('string');",
+									"        });",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Limit parameter is respected\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    const limit = parseInt(pm.request.url.query.get('limit'));",
+									"    pm.expect(jsonData.data.length).to.be.at.most(limit);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/popular/universities?limit=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"popular",
+								"universities"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "10",
+									"description": "Number of results to return"
+								}
+							]
+						},
+						"description": "Get most popular universities by student count"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Popular Majors",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status is 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Popular majors are sorted by count\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 1) {",
+									"        for (let i = 0; i < jsonData.data.length - 1; i++) {",
+									"            pm.expect(jsonData[i].count).to.be.at.least(jsonData[i + 1].count);",
+									"        }",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Each item has major and count\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    if (jsonData.data.length > 0) {",
+									"        jsonData.data.forEach(item => {",
+									"            pm.expect(item).to.have.property('major');",
+									"            pm.expect(item).to.have.property('count');",
+									"            pm.expect(item.count).to.be.a('number');",
+									"            pm.expect(item.major).to.be.a('string');",
+									"        });",
+									"    }",
+									"});",
+									"",
+									"pm.test(\"Limit parameter is respected\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    const limit = parseInt(pm.request.url.query.get('limit'));",
+									"    pm.expect(jsonData.data.length).to.be.at.most(limit);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/popular/majors?limit=10",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"popular",
+								"majors"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "10",
+									"description": "Number of results to return"
+								}
+							]
+						},
+						"description": "Get most popular majors by student count"
 					},
 					"response": []
 				},

--- a/src/controllers/lookupController.js
+++ b/src/controllers/lookupController.js
@@ -459,6 +459,144 @@ class LookupController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/universities
+   * Get all unique universities
+   */
+  async getUniversities(req, res, next) {
+    try {
+      const universities = await lookupService.getUniversities();
+
+      res.status(200).json({
+        success: true,
+        message: 'Universities retrieved successfully',
+        data: universities,
+        count: universities.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/majors
+   * Get all unique majors
+   */
+  async getMajors(req, res, next) {
+    try {
+      const majors = await lookupService.getMajors();
+
+      res.status(200).json({
+        success: true,
+        message: 'Majors retrieved successfully',
+        data: majors,
+        count: majors.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/search/universities
+   * Search universities with query parameter
+   */
+  async searchUniversities(req, res, next) {
+    try {
+      const { q: query, limit = 10 } = req.query;
+
+      const universities = await lookupService.getUniversities();
+      const results = lookupService.searchInList(universities, query, parseInt(limit));
+
+      res.status(200).json({
+        success: true,
+        message: 'University search completed successfully',
+        data: results,
+        query,
+        count: results.length,
+        totalAvailable: universities.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/search/majors
+   * Search majors with query parameter
+   */
+  async searchMajors(req, res, next) {
+    try {
+      const { q: query, limit = 10 } = req.query;
+
+      const majors = await lookupService.getMajors();
+      const results = lookupService.searchInList(majors, query, parseInt(limit));
+
+      res.status(200).json({
+        success: true,
+        message: 'Major search completed successfully',
+        data: results,
+        query,
+        count: results.length,
+        totalAvailable: majors.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/popular/universities
+   * Get most popular universities by count
+   */
+  async getPopularUniversities(req, res, next) {
+    try {
+      const { limit = 10 } = req.query;
+
+      const universitiesWithCount = await lookupService.getUniversitiesWithCount();
+      const popularUniversities = universitiesWithCount.slice(0, parseInt(limit));
+
+      res.status(200).json({
+        success: true,
+        message: 'Popular universities retrieved successfully',
+        data: popularUniversities,
+        count: popularUniversities.length,
+        totalAvailable: universitiesWithCount.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/popular/majors
+   * Get most popular majors by count
+   */
+  async getPopularMajors(req, res, next) {
+    try {
+      const { limit = 10 } = req.query;
+
+      const majorsWithCount = await lookupService.getMajorsWithCount();
+      const popularMajors = majorsWithCount.slice(0, parseInt(limit));
+
+      res.status(200).json({
+        success: true,
+        message: 'Popular majors retrieved successfully',
+        data: popularMajors,
+        count: popularMajors.length,
+        totalAvailable: majorsWithCount.length,
+        timestamp: new Date().toISOString()
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 module.exports = new LookupController();

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,8 @@ app.get('/api', (req, res) => {
       companies: '/api/companies',
       students: '/api/students',
       industries: '/api/industries',
+      universities: '/api/universities',
+      majors: '/api/majors',
       techRoles: '/api/tech-roles',
       docs: '/api/docs'
     }
@@ -104,6 +106,7 @@ app.get('/api/docs', (req, res) => {
         'POST /students/validate-photo': 'Validate student photo upload'
       },
       lookup: {
+        'GET /lookup/all': 'Get all lookup data',
         'GET /industries': 'Get industries list',
         'GET /tech-roles': 'Get tech roles list',
         'GET /tech-role-categories': 'Get tech role categories',
@@ -111,8 +114,13 @@ app.get('/api/docs', (req, res) => {
         'GET /search/industries': 'Search industries',
         'GET /search/tech-roles': 'Search tech roles',
         'GET /suggestions/tech-skills': 'Get tech skill suggestions',
+        'GET /universities': 'Returns array of unique universities',
+        'GET /search/universities?q=query': 'Search universities with fuzzy matching',
+        'GET /popular/universities': 'Universities sorted by student count',
+        'GET /majors:': 'Returns array of unique academic majors',
+        'GET /search/majors?q=query': 'Search majors with fuzzy matching',
+        'GET /popular/majors': 'Majors sorted by student count',
         'POST /validate/tech-skills': 'Validate tech skills array',
-        'GET /lookup/all': 'Get all lookup data',
         'GET /popular/industries': 'Get popular industries',
         'GET /popular/tech-roles': 'Get popular tech roles',
         'GET /popular/tech-skills': 'Get popular tech skills',

--- a/src/routes/lookup.js
+++ b/src/routes/lookup.js
@@ -25,6 +25,18 @@ router.get('/tech-roles', lookupController.getTechRoles);
 router.get('/tech-role-categories', lookupController.getTechRoleCategories);
 
 /**
+ * GET /api/universities
+ * Get all unique universities
+ */
+router.get('/universities', lookupController.getUniversities);
+
+/**
+ * GET /api/majors
+ * Get all unique majors
+ */
+router.get('/majors', lookupController.getMajors);
+
+/**
  * GET /api/tech-roles/category/:category
  * Get tech roles by specific category
  */
@@ -41,6 +53,18 @@ router.get('/search/industries', validateSearchQuery, lookupController.searchInd
  * Search tech roles with query parameter
  */
 router.get('/search/tech-roles', validateSearchQuery, lookupController.searchTechRoles);
+
+/**
+ * GET /api/search/universities
+ * Search universities with query parameter
+ */
+router.get('/search/universities', validateSearchQuery, lookupController.searchUniversities);
+
+/**
+ * GET /api/search/majors
+ * Search majors with query parameter
+ */
+router.get('/search/majors', validateSearchQuery, lookupController.searchMajors);
 
 /**
  * GET /api/suggestions/tech-skills
@@ -77,6 +101,18 @@ router.get('/popular/tech-roles', lookupController.getPopularTechRoles);
  * Get most popular tech skills by count
  */
 router.get('/popular/tech-skills', lookupController.getPopularTechSkills);
+
+/**
+ * GET /api/popular/universities
+ * Get most popular universities by count
+ */
+router.get('/popular/universities', lookupController.getPopularUniversities);
+
+/**
+ * GET /api/popular/majors
+ * Get most popular majors by count
+ */
+router.get('/popular/majors', lookupController.getPopularMajors);
 
 /**
  * POST /api/cache/clear


### PR DESCRIPTION
  - Add GET /api/universities and /api/majors endpoints
  - Add search functionality for universities and majors
  - Add popularity-based endpoints for universities and majors
  - Update Postman collection with comprehensive test coverage
  - Add all 6 new endpoints with validation tests
  - Update collection to cover 49 total endpoints
  - Closes BUG 001